### PR TITLE
Fix delete_booking to avoid deprecated query get

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -47,7 +47,7 @@ def create_booking(db: Session, booking: schemas.booking.BookingCreate):
 
 
 def delete_booking(db: Session, booking_id: int):
-    booking = db.query(models.booking.Booking).get(booking_id)
+    booking = db.get(models.booking.Booking, booking_id)
     if booking:
         db.delete(booking)
         db.commit()


### PR DESCRIPTION
## Summary
- replace deprecated `query(...).get()` with `Session.get` in `delete_booking`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686279bc71508333885259690e9d4158