### PR TITLE
Add booking status support

### DIFF
--- a/app/api/bookings.py
+++ b/app/api/bookings.py
@@ -29,3 +29,11 @@ def delete_existing_booking(booking_id: int, db: Session = Depends(get_db)):
     if not booking:
         raise HTTPException(status_code=404, detail="Booking not found")
     return {"ok": True}
+
+
+@router.post("/{booking_id}/confirm", response_model=schemas.Booking)
+def confirm_existing_booking(booking_id: int, db: Session = Depends(get_db)):
+    booking = crud.confirm_booking(db, booking_id)
+    if not booking:
+        raise HTTPException(status_code=404, detail="Booking not found")
+    return booking

--- a/app/crud.py
+++ b/app/crud.py
@@ -39,7 +39,7 @@ def create_booking(db: Session, booking: schemas.booking.BookingCreate):
     if overlapping:
         raise ValueError("Time slot already booked")
 
-    db_booking = models.booking.Booking(**booking.dict())
+    db_booking = models.booking.Booking(**booking.dict(), booking_status="pending")
     db.add(db_booking)
     db.commit()
     db.refresh(db_booking)
@@ -51,4 +51,14 @@ def delete_booking(db: Session, booking_id: int):
     if booking:
         db.delete(booking)
         db.commit()
+    return booking
+
+
+def confirm_booking(db: Session, booking_id: int):
+    booking = db.get(models.booking.Booking, booking_id)
+    if not booking:
+        return None
+    booking.booking_status = "confirmed"
+    db.commit()
+    db.refresh(booking)
     return booking

--- a/app/models/booking.py
+++ b/app/models/booking.py
@@ -10,3 +10,4 @@ class Booking(Base):
     name = Column(String, index=True)
     start = Column(DateTime, nullable=False, index=True)
     end = Column(DateTime, nullable=False, index=True)
+    booking_status = Column(String, nullable=False, default="pending")

--- a/app/schemas/booking.py
+++ b/app/schemas/booking.py
@@ -14,6 +14,7 @@ class BookingCreate(BookingBase):
 
 class Booking(BookingBase):
     id: int
+    booking_status: str
 
     class Config:
         orm_mode = True

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,8 +5,9 @@
     <style>
         table { border-collapse: collapse; }
         th, td { border: 1px solid #ccc; padding: 5px; text-align: center; }
-        .booked { background-color: #f2a0a0; }
-        .available { background-color: #a0f2a0; cursor: pointer; }
+        .available { background-color: #cccccc; cursor: pointer; }
+        .pending { background-color: orange; }
+        .confirmed { background-color: #a0f2a0; }
     </style>
 </head>
 <body>
@@ -52,8 +53,13 @@ async function loadCalendar() {
                 return start.getTime() <= cellDate.getTime() && end.getTime() > cellDate.getTime();
             });
             if (booking) {
-                cell.className = 'booked';
-                cell.textContent = booking.name;
+                if (booking.booking_status === 'pending') {
+                    cell.className = 'pending';
+                    cell.textContent = 'awaiting approval';
+                } else {
+                    cell.className = 'confirmed';
+                    cell.textContent = booking.name;
+                }
             } else {
                 cell.className = 'available';
                 cell.addEventListener('click', () => createBooking(cellDate));
@@ -78,7 +84,7 @@ async function createBooking(start) {
         body: JSON.stringify({name, start: start.toISOString(), end: end.toISOString()})
     });
     if (resp.ok) {
-        alert('Booking created');
+        alert('Booking request created');
         loadCalendar();
     } else {
         const data = await resp.json();


### PR DESCRIPTION
## Summary
- add `booking_status` field to Booking model and schema
- default new bookings to `pending` and allow confirmation
- create endpoint to confirm bookings
- update calendar UI to use new statuses and grey available slots
- maintain clean state in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d49220688333b181aeec6715b2f1