### PR TITLE
Add Docker deployment files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ A simple FastAPI application to manage tennis court reservations.
 3. Start the server: `uvicorn app.main:app --reload`
 4. Access the interactive docs at `http://localhost:8000/docs`
 
+## Docker
+1. Build the image: `docker build -t tennis-booking .`
+2. Run the container:
+   ```bash
+   docker run -p 8000:8000 -e DATABASE_URL=sqlite:///./booking.db tennis-booking
+   ```
+   The API will be available at `http://localhost:8000`.
+
+## Docker Compose
+A `docker-compose.yml` is provided to persist the SQLite database in a volume:
+```bash
+docker compose up
+```
+This starts the application on port 8000 and stores `booking.db` in a named volume.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=sqlite:////data/booking.db
+    volumes:
+      - db-data:/data
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- containerize the app with a simple Dockerfile
- add a docker compose file for the SQLite database
- document Docker usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862eb55b93c8333a83fe30db8f935a1